### PR TITLE
feat: add login and register API module 

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,7 @@ module.exports = function (api) {
         {
           root: ['./src'],
           alias: {
+            '@/apis': './src/apis',
             '@/components': './src/components',
             '@/screens': './src/screens',
             '@/constants': './src/constants',

--- a/src/apis/API.ts
+++ b/src/apis/API.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { ApiError, ApiResponse } from '@/constants/types';
-import { API_URL } from '@/constants/apis/server';
+import { API_URL } from '@/constants/apis';
 
 /**
  * API 요청에서 범용적으로 사용할 Axios Instance 생성

--- a/src/apis/API.ts
+++ b/src/apis/API.ts
@@ -13,6 +13,22 @@ const API = axios.create({
 });
 
 /**
+ * API 응답의 Authorization Header에 jwt 토큰이 담겼다면, 이를 인계하는 intercepter
+ */
+API.interceptors.response.use((res: AxiosResponse) => {
+  // Response Header 내의 Authorization 속성에 값이 존재하는지를 확인
+  if (res.headers.authorization) {
+    const token = res.headers.authorization.split(' ')[1]; // Bearer [token] 형식이므로, 뒤의 token만 파싱
+    return {
+      ...res,
+      data: { token, ...res.data },
+    };
+  }
+  // 그렇지 않을 경우 인계 받은 Response 데이터를 그대로 패싱
+  return res;
+});
+
+/**
  * API 통신 과정에서 발생한 에러를 클라이언트에 객체로 인계하는 함수
  * @param err API 통신 과정에서 발생한 에러 데이터
  * @returns 클라이언트에게 인계할 에러 객체 (ApiError)

--- a/src/apis/API.ts
+++ b/src/apis/API.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
-import { ApiError, ApiResponse } from '@/constants/types';
+import { ApiError, ApiResponse, ApiSuccess } from '@/constants/types';
 import { API_URL } from '@/constants/apis';
 
 /**
@@ -27,7 +27,7 @@ function handleApiError(err: unknown): ApiError {
       return {
         code: errResponse.code,
         msg: errResponse.msg,
-        data: errResponse.data ?? null,
+        data: errResponse.data ?? undefined,
       };
     }
     // 요청을 전송하였으나 서버에서 응답을 받지 못한 경우
@@ -58,9 +58,12 @@ export async function getAsync<T>(
   config?: AxiosRequestConfig,
 ): ApiResponse<T> {
   try {
-    const response = await API.get<T, AxiosResponse<T, any>, any>(url, {
-      ...config,
-    });
+    const response = await API.get<T, AxiosResponse<ApiSuccess<T>, any>, any>(
+      url,
+      {
+        ...config,
+      },
+    );
     return { isSuccess: true, result: response.data };
   } catch (err) {
     return { isSuccess: false, result: handleApiError(err) };
@@ -83,9 +86,13 @@ export async function postAsync<T, D>(
   config?: AxiosRequestConfig,
 ): ApiResponse<T> {
   try {
-    const response = await API.post<T, AxiosResponse<T, D>, D>(url, data, {
-      ...config,
-    });
+    const response = await API.post<T, AxiosResponse<ApiSuccess<T>, D>, D>(
+      url,
+      data,
+      {
+        ...config,
+      },
+    );
     return { isSuccess: true, result: response.data };
   } catch (err) {
     return { isSuccess: false, result: handleApiError(err) };
@@ -108,9 +115,13 @@ export async function patchAsync<T, D>(
   config?: AxiosRequestConfig,
 ): ApiResponse<T> {
   try {
-    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
-      ...config,
-    });
+    const response = await API.patch<T, AxiosResponse<ApiSuccess<T>, D>, D>(
+      url,
+      data,
+      {
+        ...config,
+      },
+    );
     return { isSuccess: true, result: response.data };
   } catch (err) {
     return { isSuccess: false, result: handleApiError(err) };
@@ -131,9 +142,12 @@ export async function deleteAsync<T>(
   config?: AxiosRequestConfig,
 ): ApiResponse<T> {
   try {
-    const response = await API.patch<T, AxiosResponse<T, any>, any>(url, {
-      ...config,
-    });
+    const response = await API.patch<T, AxiosResponse<ApiSuccess<T>, any>, any>(
+      url,
+      {
+        ...config,
+      },
+    );
     return { isSuccess: true, result: response.data };
   } catch (err) {
     return { isSuccess: false, result: handleApiError(err) };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,6 +1,8 @@
 import { postAsync } from '@/apis/API';
 import { ApiResponse } from '@/constants/types';
 
+type DuplicateOptionType = 'email' | 'nickname';
+
 /**
  * 신규 유저의 회원가입을 처리하는 함수 registerAsync
  * @param email 유저의 이메일
@@ -21,6 +23,23 @@ export async function registerAsync(
 ): ApiResponse<undefined> {
   const response = await postAsync<undefined, any>('/auth/sign-up', undefined, {
     params: { email, password, name, nickname, age, gender },
+  });
+  return response;
+}
+
+/**
+ * 이메일 혹은 닉네임 중복을 확인할 함수 checkDuplicateAsync
+ * @param option 닉네임, 이메일
+ * @param value 중복 여부를 확인할 데이터
+ * @returns 중복일 경우 409 에러 반환, 미중복일 경우 200
+ */
+export async function checkDuplicateAsync(
+  option: DuplicateOptionType,
+  value: string,
+): ApiResponse<undefined> {
+  // TO-DO : request data 에 any type 강제 해결 필요
+  const response = await postAsync<undefined, any>(`/auth/check-${option}`, {
+    [option]: value,
   });
   return response;
 }

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,26 @@
+import { postAsync } from '@/apis/API';
+import { ApiResponse } from '@/constants/types';
+
+/**
+ * 신규 유저의 회원가입을 처리하는 함수 registerAsync
+ * @param email 유저의 이메일
+ * @param password 유저의 비밀번호
+ * @param name 유저의 실명
+ * @param nickname 유저의 닉네임
+ * @param age 유저의 나이
+ * @param gender 유저의 성별
+ * @returns 가입 성공 시 201, 실패 시 에러 반환 (1001, 500 등)
+ */
+export async function registerAsync(
+  email: string,
+  password: string,
+  name: string,
+  nickname: string,
+  age: number,
+  gender: 'm' | 'f',
+): ApiResponse<undefined> {
+  const response = await postAsync<undefined, any>('/auth/sign-up', undefined, {
+    params: { email, password, name, nickname, age, gender },
+  });
+  return response;
+}

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,7 +1,10 @@
 import { postAsync } from '@/apis/API';
 import { ApiResponse } from '@/constants/types';
-
-type DuplicateOptionType = 'email' | 'nickname';
+import {
+  DuplicateOptionType,
+  LoginAsyncInput,
+  LoginAsyncOutput,
+} from '@/constants/types';
 
 /**
  * 신규 유저의 회원가입을 처리하는 함수 registerAsync
@@ -24,6 +27,23 @@ export async function registerAsync(
   const response = await postAsync<undefined, any>('/auth/sign-up', undefined, {
     params: { email, password, name, nickname, age, gender },
   });
+  return response;
+}
+
+/**
+ * 기존 유저의 로그인을 처리하는 함수 loginAsync
+ * @param email 유저의 이메일
+ * @param password 유저의 비밀번호
+ * @returns 성공 시 JWT 액세스 토큰 인계, 실패 시 에러 객체 반환
+ */
+export async function loginAsync(
+  email: string,
+  password: string,
+): ApiResponse<LoginAsyncOutput> {
+  const response = await postAsync<LoginAsyncOutput, LoginAsyncInput>(
+    '/auth/sign-in',
+    { email, password },
+  );
   return response;
 }
 

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,6 +1,7 @@
 import { postAsync } from '@/apis/API';
-import { ApiResponse } from '@/constants/types';
 import {
+  ApiResponse,
+  RegisterGenderType,
   DuplicateOptionType,
   LoginAsyncInput,
   LoginAsyncOutput,
@@ -13,7 +14,7 @@ import {
  * @param name 유저의 실명
  * @param nickname 유저의 닉네임
  * @param age 유저의 나이
- * @param gender 유저의 성별
+ * @param gender 유저의 성별 (m, w)
  * @returns 가입 성공 시 201, 실패 시 에러 반환 (1001, 500 등)
  */
 export async function registerAsync(
@@ -22,7 +23,7 @@ export async function registerAsync(
   name: string,
   nickname: string,
   age: number,
-  gender: 'm' | 'f',
+  gender: RegisterGenderType,
 ): ApiResponse<undefined> {
   const response = await postAsync<undefined, any>('/auth/sign-up', undefined, {
     params: { email, password, name, nickname, age, gender },

--- a/src/constants/apis/index.ts
+++ b/src/constants/apis/index.ts
@@ -1,0 +1,1 @@
+export { API_URL } from './server';

--- a/src/constants/apis/server.ts
+++ b/src/constants/apis/server.ts
@@ -1,2 +1,2 @@
 export const API_URL =
-  'ec2-15-164-222-91.ap-northeast-2.compute.amazonaws.com:8080/api/v1' as const;
+  'ec2-13-124-142-73.ap-northeast-2.compute.amazonaws.com:8080/api/v1' as const;

--- a/src/constants/types/APITypes.ts
+++ b/src/constants/types/APITypes.ts
@@ -3,8 +3,21 @@
  * @param T 요청 성공 시 인계 받은 데이터 타입
  */
 export type ApiResponse<T> = Promise<
-  { isSuccess: true; result: T } | { isSuccess: false; result: ApiError }
+  | { isSuccess: true; result: ApiSuccess<T> }
+  | { isSuccess: false; result: ApiError }
 >;
+
+/**
+ * API 호출로 서버에서 받은 데이터와 관련된 interface
+ */
+export interface ApiSuccess<T> {
+  /** 백엔드 측에서 전송한 HTTP Status Code */
+  code: number;
+  /** 백엔드 측에서 전송한 응답 메세지 */
+  msg: string;
+  /** 백엔드 측에서 전송한 응답 데이터 */
+  data?: T;
+}
 
 /**
  * API 호출 과정에서 발생한 에러와 관련된 interface
@@ -15,5 +28,17 @@ export interface ApiError {
   /** 백엔드 측에서 전송한 에러 관련 메세지 */
   msg: string;
   /** 백엔드 측에서 전송한 에러 관련 데이터 */
-  data?: any;
+  data?: {
+    errors: ApiErrorFieldData[];
+  };
+}
+
+/**
+ * API 호출 과정에서 발생한 에러 정보 관련 interface
+ */
+interface ApiErrorFieldData {
+  /** 에러를 발생시킨 field 요소*/
+  field: string;
+  /** 해당 field에서 발생한 구체적인 에러 원인 */
+  msg: string;
 }

--- a/src/constants/types/AuthTypes.ts
+++ b/src/constants/types/AuthTypes.ts
@@ -18,4 +18,6 @@ export interface LoginAsyncOutput {
 
 export type InputNameType = 'id' | 'pw' | 'pwCheck';
 
+export type RegisterGenderType = 'm' | 'w';
+
 export type DuplicateOptionType = 'email' | 'nickname';

--- a/src/constants/types/AuthTypes.ts
+++ b/src/constants/types/AuthTypes.ts
@@ -7,4 +7,15 @@ export interface RegisterInputsType extends LoginInputsType {
   pwCheck: string;
 }
 
+export interface LoginAsyncInput {
+  email: string;
+  password: string;
+}
+
+export interface LoginAsyncOutput {
+  token: string;
+}
+
 export type InputNameType = 'id' | 'pw' | 'pwCheck';
+
+export type DuplicateOptionType = 'email' | 'nickname';

--- a/src/constants/types/index.ts
+++ b/src/constants/types/index.ts
@@ -2,6 +2,9 @@ export type {
   LoginInputsType,
   RegisterInputsType,
   InputNameType,
+  LoginAsyncInput,
+  LoginAsyncOutput,
+  DuplicateOptionType,
 } from './authTypes';
 
 export type { ApiResponse, ApiSuccess, ApiError } from './apiTypes';

--- a/src/constants/types/index.ts
+++ b/src/constants/types/index.ts
@@ -5,6 +5,7 @@ export type {
   LoginAsyncInput,
   LoginAsyncOutput,
   DuplicateOptionType,
+  RegisterGenderType,
 } from './authTypes';
 
 export type { ApiResponse, ApiSuccess, ApiError } from './apiTypes';

--- a/src/constants/types/index.ts
+++ b/src/constants/types/index.ts
@@ -4,4 +4,4 @@ export type {
   InputNameType,
 } from './authTypes';
 
-export type { ApiResponse, ApiError } from './apiTypes';
+export type { ApiResponse, ApiSuccess, ApiError } from './apiTypes';

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
 
     config.resolve.alias = {
       ...config.resolve.alias,
+      '@/apis': path.resolve(__dirname, '../src/apis'),
       '@/components': path.resolve(__dirname, '../src/components'),
       '@/screens': path.resolve(__dirname, '../src/screens'),
       '@/routes': path.resolve(__dirname, '../src/routes'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
+      "@/apis/*": ["./src/apis/*"],
       "@/components/*": ["./src/components/*"],
       "@/screens/*": ["./src/screens/*"],
       "@/constants/*": ["./src/constants/*"],


### PR DESCRIPTION
## Jira Issue 번호

[#35](https://gongback.atlassian.net/browse/WEEDA-35)
[#34](https://gongback.atlassian.net/browse/WEEDA-34)

## 작업 내용
- apis 폴더에 대한 절대 경로 설정을 babel, tsconfig 에 적용
- API 인터페이스를 서버에서 인계받은 데이터 양식에 맞춰 리팩토링
- 회원가입 함수 registerAsync 구현 (프로필 사진이 없는 경우만 부분 구현)
- 이메일, 닉네임 중복 체크 함수 checkedDuplicateAsync 구현
- 로그인 함수 loginAsync 구현
- 서버로부터 인계받은 response header에 담긴 jwt 토큰을 가져오기 위해 axios 인터셉터 구현

## Checklist

- [X] Code Review 요청
- [X] PR 제목 commit convention에 맞는지 확인
- [X] Label 설정
- [X] Jira 코드 리뷰 상태로 변경